### PR TITLE
Fixed horizontal scroll overhang issue.

### DIFF
--- a/style/foundryStyle.css
+++ b/style/foundryStyle.css
@@ -35,6 +35,7 @@ html, body {
 }
 body {
 	line-height: 1;
+	width: 100%;
 }
 ol, ul {
 	list-style: none;
@@ -99,7 +100,6 @@ section .wrapper {
 	margin: 0 auto;
 	padding: 30px;
 	padding-top: 50px;
-	width: 800px;
 	min-height: 450px;
 }
 section .bold {
@@ -134,6 +134,7 @@ h3 {
 }
 
 #splash, #splash3 {
+	width: 100%;
 	height: 100%;
 	color: #909090;
 	text-align: center;


### PR DESCRIPTION
In `foundryStyle.css`:  Removed fixed section width in `section .wrapper` so that content no longer extends past background.  Closes #5.

@ManickYoj, please merge when you can.
